### PR TITLE
Introduce `fzctl` to read daemon state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.0.19
 
+- Add fzctl to check the daemon state
 - Add scripts for testing HTTP
 
 ## v0.0.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add fzctl to check the daemon state
 - Add scripts for testing HTTP
+- Slight improvements to the man pages
 
 ## v0.0.18
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 SHELL := /bin/bash
 
-VERSION = $(shell cat cmd/fz/fz.go | awk '/const VERSION/ { gsub(/"/,"",$$NF); print $$NF }')
+FZ_VERSION := $(shell cat cmd/fz/fz.go | awk '/const VERSION/ { gsub(/"/,"",$$NF); print $$NF }')
+FZCTL_VERSION := $(shell cat cmd/fzctl/fzctl.go | awk '/const VERSION/ { gsub(/"/,"",$$NF); print $$NF }')
+VERSION := $(FZ_VERSION)
 
-release: prerelease_tests release_notes.txt dist/fz_openbsd_amd64 dist/fz_linux_amd64 dist/plugins.tar.gz
+release: prerelease_tests release_notes.txt dist/fz_openbsd_amd64 dist/fz_linux_amd64 dist/fzctl_openbsd_amd64 dist/fzctl_linux_amd64 dist/plugins.tar.gz
 	gh release create $(VERSION) -F release_notes.txt
-	gh release upload $(VERSION) dist/fz_* dist/plugins.tar.gz
+	gh release upload $(VERSION) dist/fz_* dist/fzctl_* dist/plugins.tar.gz
 
-devrelease: clean predevrelease_tests dist/fz_linux_amd64 dist/plugins.tar.gz
+devrelease: gitsha := $(shell git rev-parse HEAD)
+devrelease: clean predevrelease_tests dist/fz_linux_amd64 dist/fzctl_linux_amd64 dist/plugins.tar.gz
 	ssh janx build_flamingzombies/build_dev $(gitsha)
 	scp dist/fz_* janx:/var/www/htdocs/artifacts.altos/flamingzombies/dev/
+	scp dist/fzctl_* janx:/var/www/htdocs/artifacts.altos/flamingzombies/dev/
 	scp dist/plugins.tar.gz janx:/var/www/htdocs/artifacts.altos/flamingzombies/dev/
 	scp scripts/openbsd_rc janx:/var/www/htdocs/artifacts.altos/flamingzombies/dev/
 
@@ -26,10 +30,22 @@ dist/fz_linux_amd64: | dist
 	CGO_ENABLED=0 go build ./cmd/fz/fz.go
 	mv fz $@
 
+dist/fzctl_linux_amd64: | dist
+	mkdir -p $$(dirname $@)
+	CGO_ENABLED=0 go build ./cmd/fzctl/fzctl.go
+	mv fzctl $@
+
 dist/fz_openbsd_amd64: gitsha := $(shell git rev-parse HEAD)
 dist/fz_openbsd_amd64: prerelease_tests | dist
 	ssh janx build_flamingzombies/build $(gitsha)
 	wget http://artifacts.altos/flamingzombies/openbsd/$(VERSION)/fz \
+		-O $@
+	chmod 755 $@
+
+dist/fzctl_openbsd_amd64: gitsha := $(shell git rev-parse HEAD)
+dist/fzctl_openbsd_amd64: prerelease_tests | dist
+	ssh janx build_flamingzombies/build $(gitsha)
+	wget http://artifacts.altos/flamingzombies/openbsd/$(VERSION)/fzctl \
 		-O $@
 	chmod 755 $@
 
@@ -42,6 +58,7 @@ dist/man/man1 doc/man1 dist:
 	mkdir -p $@
 
 prerelease_tests: test
+	[[ "$(FZCTL_VERSION)" == "$(FZ_VERSION)" ]]
 	git status | grep -q "nothing to commit"
 	git push
 	git fetch --tags

--- a/cmd/fz/fz.go
+++ b/cmd/fz/fz.go
@@ -11,7 +11,7 @@ import (
 	"nullprogram.com/x/optparse"
 )
 
-const VERSION = "v0.0.18"
+const VERSION = "v0.0.19"
 
 var config fz.Config
 var configtestMode = false
@@ -31,6 +31,10 @@ func init() {
 
 	if os.Getenv("FZ_LOG_FILE") == "" {
 		os.Setenv("FZ_LOG_FILE", "stdout")
+	}
+
+	if os.Getenv("FZ_LISTEN") == "" {
+		os.Setenv("FZ_LISTEN", "127.0.0.1:5891")
 	}
 
 	options := []optparse.Option{
@@ -61,7 +65,7 @@ func init() {
 			usage()
 			return
 		case "version":
-			fmt.Printf("flamingzombies %s\n", VERSION)
+			fmt.Printf("fz %s\n", VERSION)
 			os.Exit(0)
 		}
 	}

--- a/cmd/fzctl/fzctl.go
+++ b/cmd/fzctl/fzctl.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"time"
+
+	"nullprogram.com/x/optparse"
+)
+
+const VERSION = "v0.0.19"
+
+type taskData struct {
+	Name           string    `json:"name"`
+	State          string    `json:"state"`
+	LastRun        time.Time `json:"last_run"`
+	LastOk         time.Time `json:"last_ok"`
+	Measurements   []bool    `json:"measurements"`
+	ExecutionCount int       `json:"execution_count"`
+	OKCount        int       `json:"ok_count"`
+	FailCount      int       `json:"fail_count"`
+	ErrorCount     int       `json:"error_count"`
+}
+
+var tasks []taskData
+var cmd = "list"
+var subcmds = []string{}
+
+func init() {
+	if os.Getenv("FZ_LISTEN") == "" {
+		os.Setenv("FZ_LISTEN", "127.0.0.1:5891")
+	}
+
+	options := []optparse.Option{
+		{"help", 'h', optparse.KindNone},
+		{"host", 'H', optparse.KindRequired},
+		{"version", 'V', optparse.KindNone},
+	}
+
+	results, _, err := optparse.Parse(options, os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	optCount := 0
+	for _, result := range results {
+		switch result.Long {
+		case "help":
+			usage()
+			return
+		case "host":
+			os.Setenv("FZ_LISTEN", result.Optarg)
+			optCount += 2
+		case "version":
+			fmt.Printf("fzctl %s\n", VERSION)
+			os.Exit(0)
+		}
+	}
+
+	if len(os.Args) > optCount+1 {
+		cmd = os.Args[optCount+1]
+	}
+
+	if len(os.Args) > optCount+2 {
+		subcmds = os.Args[optCount+2:]
+	}
+}
+
+func main() {
+	switch cmd {
+	case "list":
+		list()
+	case "show":
+		show()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", cmd)
+		os.Exit(1)
+	}
+}
+
+func list() {
+	for _, s := range subcmds {
+		if s != "ok" && s != "fail" && s != "unknown" {
+			fmt.Fprintf(os.Stderr, "Unsupported subcommand: %s\n", s)
+			fmt.Fprintln(os.Stderr, "  allowed values are 'ok', 'fail', or 'unknown'.")
+			os.Exit(1)
+		}
+	}
+
+	fetchTasks()
+
+	if len(subcmds) == 0 {
+		subcmds = []string{"ok", "fail", "unknown"}
+	}
+	for _, s := range subcmds {
+		for _, t := range tasks {
+			if t.State == s {
+				fmt.Printf("%-40s\t%s\n", t.Name, t.State)
+			}
+		}
+	}
+}
+
+func show() {
+	if len(subcmds) == 0 {
+		fmt.Fprintln(os.Stderr, "No task was provided.")
+		os.Exit(1)
+	}
+
+	fetchTasks()
+
+	for i, s := range subcmds {
+		for _, t := range tasks {
+			if t.Name == s {
+				if i != 0 {
+					fmt.Println("")
+				}
+
+				fmt.Printf("%-20s%s\n", "name:", t.Name)
+				fmt.Printf("%-20s%s\n", "state:", t.State)
+				fmt.Printf("%-20s%s ago\n", "last execution:", time.Now().Sub(t.LastRun))
+				fmt.Printf("%-20s%s ago\n", "last success:", time.Now().Sub(t.LastOk))
+				fmt.Printf("%-20s%d\n", "executions:", t.ExecutionCount)
+				fmt.Printf("%-20s%d\n", "failures:", t.FailCount)
+				fmt.Printf("%-20s%d\n", "errors:", t.ErrorCount)
+			}
+		}
+	}
+}
+
+func fetchTasks() {
+	data, err := readFromNetwork(fmt.Sprintf("%s", os.Getenv("FZ_LISTEN")))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		var t taskData
+		err = json.Unmarshal(scanner.Bytes(), &t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
+			os.Exit(1)
+		}
+
+		tasks = append(tasks, t)
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func readFromNetwork(addr string) ([]byte, error) {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 1)
+	var data []byte
+
+	for {
+		_, err := conn.Read(buf)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return []byte{}, err
+		}
+
+		data = append(data[:], buf[:]...)
+	}
+
+	return data, nil
+
+	//fmt.Println("Read", len(data), "bytes from the connection:", string(data[:len(data)]))
+}
+
+func usage() {
+	fmt.Println("Usage:")
+	fmt.Println("  fzctl [OPTIONS] <command> [subcommand]")
+	fmt.Println("")
+	fmt.Println("Options:")
+	fmt.Println("  -h, --help                  This help")
+	fmt.Println("  -H, --host <ip:port>        Host to connect to")
+	fmt.Println("  -V, --version               Version")
+	fmt.Println("")
+	fmt.Println("Commands:")
+	fmt.Println("  list [ok] [fail] [unknown]  List the running tasks")
+	fmt.Println("  show <task>                 Show the details of a task")
+	os.Exit(0)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,7 @@ go 1.21.5
 require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sirupsen/logrus v1.9.3
+	nullprogram.com/x/optparse v1.0.0
 )
 
-require (
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
-	nullprogram.com/x/optparse v1.0.0 // indirect
-)
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/lib/fz/config.go
+++ b/lib/fz/config.go
@@ -73,6 +73,10 @@ func ReadConfig() Config {
 		config.LogLevel = os.Getenv("FZ_DIRECTORY")
 	}
 
+	if config.ListenAddress == "" {
+		config.LogLevel = os.Getenv("FZ_HOST")
+	}
+
 	for i, t := range config.Tasks {
 		if t.Retries == 0 {
 			if config.Defaults.Retries == 0 {

--- a/lib/fz/config.go
+++ b/lib/fz/config.go
@@ -74,7 +74,7 @@ func ReadConfig() Config {
 	}
 
 	if config.ListenAddress == "" {
-		config.LogLevel = os.Getenv("FZ_HOST")
+		config.LogLevel = os.Getenv("FZ_LISTEN")
 	}
 
 	for i, t := range config.Tasks {

--- a/man/man1/fz.1
+++ b/man/man1/fz.1
@@ -2,11 +2,13 @@
 .Dt fz 1
 .Os
 .Sh NAME
-.Nm flamingzombies
+.Nm fz
 .Nd A monitoring scheduler to detect failure and raise alerts.
 .Sh SYNOPSIS
-.Nm fz
-[\fI\,FILE\/\fR]...
+.Nm
+.Op Fl n
+.Op Fl c Ar file
+.Op Fl l Ar error/warn/info/trace/debug
 .Sh DESCRIPTION
 The
 .Nm
@@ -31,6 +33,9 @@ The level of logs that will be emitted. Valid options are error, info, debug or 
 .It Fl V, Li --version
 Print the version information.
 .El
+.Sh SEE ALSO
+.Xr fzctl 1 ,
+.Xr flamingzombies.toml 5
 .Sh "BUGS"
 .Nm flamingzombies
 is still very immature. I'm sure it still has many bugs and missing features.

--- a/man/man1/fzctl.1
+++ b/man/man1/fzctl.1
@@ -5,8 +5,15 @@
 .Nm fzctl
 .Nd Run commands against an fz daemon.
 .Sh SYNOPSIS
-.Nm fzctl
-[\fI\,options\/\fR] \fI\,command\/\fR [\fI\,subcommand\fR]...
+.Nm
+.Op options
+.Ar list
+.Op ok|fail|unknown
+.Nm
+.Op options
+.Ar show
+.Ar task
+.Op task...
 .Sh DESCRIPTION
 Control an
 .Nm fz
@@ -26,3 +33,6 @@ daemon to connect to. The default value is 127.0.0.1:5891.
 .It Fl V, Li --version
 Print the version information.
 .El
+.Sh SEE ALSO
+.Xr fz 1 ,
+.Xr flamingzombies.toml 5

--- a/man/man1/fzctl.1
+++ b/man/man1/fzctl.1
@@ -1,0 +1,28 @@
+.Dd ${BUILD_DATE}
+.Dt fzctl 1
+.Os
+.Sh NAME
+.Nm fzctl
+.Nd Run commands against an fz daemon.
+.Sh SYNOPSIS
+.Nm fzctl
+[\fI\,options\/\fR] \fI\,command\/\fR [\fI\,subcommand\fR]...
+.Sh DESCRIPTION
+Control an
+.Nm fz
+daemon, or query its internal state.
+.Pp
+.Bl -tag -width Ds
+.It Fl c, Li --config
+The
+.Nm fz
+configuration file. It will connect to the
+.Xr listen_address
+unless the --host flag was supplied.
+.It Fl H, Li --host
+The IP address and port of the
+.Nm fz
+daemon to connect to. The default value is 127.0.0.1:5891.
+.It Fl V, Li --version
+Print the version information.
+.El


### PR DESCRIPTION
Introduce `fzctl` to read the state of the daemon. Later, this may be extended to control the daemon, too.