### PR TITLE
Remove support for configurable unknown_exit_code

### DIFF
--- a/lib/fz/config.go
+++ b/lib/fz/config.go
@@ -13,7 +13,6 @@ const DEFAULT_RETRIES = 5
 const DEFAULT_TIMEOUT_SECONDS = 5
 const DEFAULT_FREQUENCY_SECONDS = 300
 const DEFAULT_PRIORITY = 5
-const DEFAULT_UNKNOWN_EXIT_CODE = 3 // straight from Nagios
 
 type Defaults struct {
 	FrequencySeconds      int      `toml:"frequency"`
@@ -22,7 +21,6 @@ type Defaults struct {
 	RetryFrequencySeconds int      `toml:"retry_frequency"`
 	TimeoutSeconds        int      `toml:"timeout"` // better to put the timeout into the commmand
 	Priority              int      `toml:"priority"`
-	UnknownExitCode       int      `toml:"unknown_exit_code`
 }
 
 type Config struct {
@@ -115,14 +113,6 @@ func ReadConfig() Config {
 				config.Tasks[i].Priority = DEFAULT_PRIORITY
 			} else {
 				config.Tasks[i].Priority = config.Defaults.Priority
-			}
-		}
-
-		if t.UnknownExitCode == 0 {
-			if config.Defaults.UnknownExitCode == 0 {
-				config.Tasks[i].UnknownExitCode = DEFAULT_UNKNOWN_EXIT_CODE
-			} else {
-				config.Tasks[i].Priority = config.Defaults.UnknownExitCode
 			}
 		}
 

--- a/lib/fz/task.go
+++ b/lib/fz/task.go
@@ -15,18 +15,17 @@ import (
 )
 
 type Task struct {
-	Name                  string   `toml:"name"`              // friendly name
-	Command               string   `toml:"command"`           // command
-	Args                  []string `toml:"args"`              // command arguments
-	FrequencySeconds      int      `toml:"frequency"`         // how often to run
-	RetryFrequencySeconds int      `toml:"retry_frequency"`   // how quickly to retry when state unknown
-	TimeoutSeconds        int      `toml:"timeout"`           // how long an execution may run
-	Retries               int      `toml:"retries"`           // number of retries before changing the state
-	NotifierNames         []string `toml:"notifiers"`         // notifiers to trigger upon state change
-	Priority              int      `toml:"priority"`          // the priority of the notifications
-	ErrorBody             string   `toml:"error_body"`        // the body of the notification when entering an error state
-	RecoverBody           string   `toml:"recover_body"`      // the body of the notification when recovering from an error state
-	UnknownExitCode       int      `toml:"unknown_exit_code"` // the exit code indicating that a measurement could not be taken
+	Name                  string   `toml:"name"`            // friendly name
+	Command               string   `toml:"command"`         // command
+	Args                  []string `toml:"args"`            // command arguments
+	FrequencySeconds      int      `toml:"frequency"`       // how often to run
+	RetryFrequencySeconds int      `toml:"retry_frequency"` // how quickly to retry when state unknown
+	TimeoutSeconds        int      `toml:"timeout"`         // how long an execution may run
+	Retries               int      `toml:"retries"`         // number of retries before changing the state
+	NotifierNames         []string `toml:"notifiers"`       // notifiers to trigger upon state change
+	Priority              int      `toml:"priority"`        // the priority of the notifications
+	ErrorBody             string   `toml:"error_body"`      // the body of the notification when entering an error state
+	RecoverBody           string   `toml:"recover_body"`    // the body of the notification when recovering from an error state
 
 	// public, but unconfigurable
 	LastRun        time.Time
@@ -151,7 +150,9 @@ func (t *Task) Run() bool {
 	}).Debug(fmt.Sprintf("command returned stderr: %s", errorMessage))
 
 	switch exitCode {
-	case t.UnknownExitCode:
+	case 3: // unknown status
+		return false
+	case 124: // unknown status due to timeout
 		return false
 	case 0:
 		t.LastOk = time.Now()

--- a/man/man5/flamingzombies.toml.5
+++ b/man/man5/flamingzombies.toml.5
@@ -127,11 +127,7 @@ The priority is part of the payload sent to notification gates and is otherwise 
 This string of text is intended to be used by notifiers when raising failure alerts.
 .It Ic recover_body = Ar text
 This string of text is intended to be used by notifiers when raising recovery alerts.
-.It Ic unknown_exit_code = Ar number
-By default, an exit code of 3 denotes an unknown state. This follows the pattern set by Nagios, however unlike Nagios,
-.Xr fz
-doesn't differentiate between warning and critical exit codes.
-
+.El
 .Sh NOTIFIERS
 Notifiers raise alerts for tasks. They're triggered each time a task using it records a new measurement. Before executing the notifier command (which results in an alert being sent), each of its gates are check to be open (return exit code of zero). A notifier is only responsible for raising alerts, and should never attempt to control when alerts are sent.
 .Pp

--- a/man/man7/fz-tasks.7
+++ b/man/man7/fz-tasks.7
@@ -43,9 +43,7 @@ You could get meta, and write a task to check that the
 .Xr fz
 log_file doesn't contain any errors, but that is out of the scope of this document.
 .Pp
-Each task should check just one thing. If it cannot conduct its test for any reason, return the
-.Ar unknown_status_code
-rather than fail the test. Following this recommendation will reduce the chance of alert storms when hosts fail.
+Each task should check just one thing. When a test cannot be executed, exit with 3 rather than fail the test. This reduces the chance of alert storms when hosts fail or similar issues occur that prevent tasks from executing.
 .Sh EXAMPLES
 A very simple task to check the existence of a file:
 .Bd -literal -offset indent


### PR DESCRIPTION
Configurable exit codes are not needed. You can easily write a task that does `whatever || exit 1`.

This feature was added when I was thinking that might configure a task without a wrapper script. That wouldn't easily support pipelines, so being able to handle different exit codes was wanted.