### PR TITLE
Fail configtest with non-existent commands

### DIFF
--- a/lib/fz/config.go
+++ b/lib/fz/config.go
@@ -183,6 +183,25 @@ func ReadConfig() Config {
 		}
 	}
 
+	for _, n := range config.Notifiers {
+		if err = n.validate(); err != nil {
+			log.WithFields(log.Fields{
+				"file":          "lib/fz/config.go",
+				"notifier_name": n.Name,
+			}).Fatal(err)
+		}
+
+	}
+
+	for _, g := range config.Gates {
+		if err = g.validate(); err != nil {
+			log.WithFields(log.Fields{
+				"file":      "lib/fz/config.go",
+				"gate_name": g.Name,
+			}).Fatal(err)
+		}
+	}
+
 	return config
 }
 

--- a/lib/fz/gate.go
+++ b/lib/fz/gate.go
@@ -75,3 +75,13 @@ func (g Gate) IsOpen(t *Task) bool {
 	}).Debug(fmt.Sprintf("command exited with %d", 0))
 	return true
 }
+
+func (g Gate) validate() error {
+	if _, err := os.Stat(g.Command); os.IsNotExist(err) {
+		if _, err := os.Stat(fmt.Sprintf("%s/%s", config.Directory, g.Command)); os.IsNotExist(err) {
+			return fmt.Errorf("gate command not found")
+		}
+	}
+
+	return nil
+}

--- a/lib/fz/notifier.go
+++ b/lib/fz/notifier.go
@@ -2,6 +2,7 @@ package fz
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -39,4 +40,14 @@ func (n Notifier) gates() []*Gate {
 	}
 
 	return gs
+}
+
+func (n Notifier) validate() error {
+	if _, err := os.Stat(n.Command); os.IsNotExist(err) {
+		if _, err := os.Stat(fmt.Sprintf("%s/%s", config.Directory, n.Command)); os.IsNotExist(err) {
+			return fmt.Errorf("notifier command not found")
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
If task, notifier or gate commands are not found, the configtest must fail.