### PR TITLE
Add `task/fz_errors` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed dependency on logrus so that it can cross-compile for OpenBSD 7.5.
 - Support gatesets to combine ANDing or ORing the results of gates.
 - Improvements to the configtest
+- Add `task/fz_errors` plugin
 
 ## v0.0.19
 

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -30,4 +30,4 @@ plugins.tar.gz:
 
 .PHONY: clean
 clean:
-	rm -f $(BINS)
+	rm -f $(BINS) plugins.tar.gz

--- a/libexec/task/fz_errors
+++ b/libexec/task/fz_errors
@@ -1,0 +1,26 @@
+#!/bin/sh
+if [ $# -eq 2 ]; then
+  export FZ_LISTEN="$1:$2"
+fi
+
+_fz_online() { fzctl || exit 3; }
+_fz_tasks() { fzctl list | awk '{ print $1 }'; }
+
+# the state is unknown if fzctl cannot be called.
+_fz_online
+
+# shellcheck disable=SC2046
+fzctl show $(_fz_tasks) | awk '
+    BEGIN { errors=0 }
+    /^name:/ { name=$2 }
+    /^errors:/ {
+      if ($2>0) {
+        print name, "has experienced errors"
+        errors++
+      }
+    }
+    END {
+      if (errors>0)
+        exit 1
+    }
+  ' >&2

--- a/man/man5/flamingzombies.toml.5
+++ b/man/man5/flamingzombies.toml.5
@@ -202,6 +202,8 @@ Ensure that the md_device has the expected number of underlying block devices.
 Ping the host with a number of packets. The task succeeds if all the expected packets are received.
 .It Cm task/port_open Ar host Ar port
 Check if host has an open port.
+.It Cm task/fz_errors Ar host Ar port
+Check that none of fz's tasks have experienced an error.
 .It Cm notifier/email
 Send notification using the local MTA.
 .It Cm notifier/ntfy Ar topic


### PR DESCRIPTION
It tells you if any task on an fz daemon has experienced errors.

You would be expected to manually investigate the error and restart the daemon to reset the error counter.