### PR TITLE
Delay notifications

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -59,9 +59,15 @@ flappy has recovered
 name = "logger"
 command = "notifier/null"
 timeout = 5
-gates = [["state_change"]]
+gates = [["state_change", "defer"]]
 
 [[gate]]
 name = "state_change"
 command = "gate/state_change"
 timeout = 1
+args = ["fail"]
+
+[[gate]]
+name = "defer"
+command = "gate/defer"
+args = ["6"]

--- a/lib/fz/notification.go
+++ b/lib/fz/notification.go
@@ -87,6 +87,7 @@ X:
 				Logger.Debug("gate is closed", "gate", g.Name)
 				break X
 			}
+			Logger.Debug("gate is open", "gate", g.Name)
 		}
 		Logger.Debug("gateset is open", "gateset", gsi)
 		return true

--- a/libexec/gate/defer
+++ b/libexec/gate/defer
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+NOW="$(date +%s)"
+DEFER_SECONDS=${1:-0}
+
+case "${STATE}" in
+  "fail") [ $((LAST_OK+DEFER_SECONDS))   -lt "${NOW}" ] && exit 0 ;;
+  "ok")   [ $((LAST_FAIL+DEFER_SECONDS)) -lt "${NOW}" ] && exit 0 ;;
+esac
+
+exit 1

--- a/libexec/gate/state_change
+++ b/libexec/gate/state_change
@@ -1,2 +1,16 @@
 #!/bin/sh
-[ "${STATE_CHANGED}" = "true" ]
+
+case $1 in
+  "ok")
+    [ "${STATE}" = "ok" ]                           \
+      && [ "${LAST_NOTIFICATION}" -le "${LAST_FAIL}" ] \
+      && exit 0
+    ;;
+  "fail")
+    [ "${STATE}" = "fail" ]                           \
+      && [ "${LAST_NOTIFICATION}" -le "${LAST_OK}" ] \
+      && exit 0
+    ;;
+esac
+
+exit 1

--- a/libexec/gate/state_change
+++ b/libexec/gate/state_change
@@ -11,6 +11,9 @@ case $1 in
       && [ "${LAST_NOTIFICATION}" -le "${LAST_OK}" ] \
       && exit 0
     ;;
+  *)
+    echo "$0 was not provided a valid argument" >&2
+    ;;
 esac
 
 exit 1

--- a/man/man5/flamingzombies.toml.5
+++ b/man/man5/flamingzombies.toml.5
@@ -222,6 +222,9 @@ The gate opens after the state flips from fail to ok until a notification is sen
 .It Cm fail
 The gate opens after the state flips from ok to fail until a notification is sent.
 .El
+.It Cm gate/defer Ar seconds
+Prevent a gate from opening until it been it its state for the specified time.
+.El
 .Sh EXAMPLES
 .Pp
 A minimal configuration:

--- a/man/man5/flamingzombies.toml.5
+++ b/man/man5/flamingzombies.toml.5
@@ -226,7 +226,6 @@ The gate opens after the state flips from ok to fail until a notification is sen
 Prevent a gate from opening until it been it its state for the specified time.
 .El
 .Sh EXAMPLES
-.Pp
 A minimal configuration:
 .Bd -literal -offset indent
 [[task]]
@@ -251,7 +250,7 @@ gates = [
 [[gate]]
 name = "state_failed"
 command = "gate/state_change"
-args = "fail"
+args = ["fail"]
 .Ed
 .Pp
 This will ping 127.0.0.1 every 60 seconds. When the state changes, retries are performed at a rate of once every 5 seconds until 5 consecutive executions agree on the new state.
@@ -263,6 +262,34 @@ gate of
 is executed. The behaviour of this gate is to be open when state either changes from ok to fail. When the gate is open, the
 .Ar notifier/null
 notifier is executed.
+.Pp
+Deferring notifications:
+.Bd -literal -offset indent
+[[notifier]]
+name = "deferred_notifier"
+command = "notifier/null"
+args = []
+timeout = 5
+gates = [
+    ["state_failed", "defer_5m"]
+]
+
+[[gate]]
+name = "state_failed"
+command = "gate/state_change"
+args = ["fail"]
+
+[[gate]]
+name = "defer_5m"
+command = "gate/defer"
+args = ["300"]
+.Ed
+.Pp
+Tasks should be fast to detect issues, but it can sometimes be preferable to allow time for the task to recover before raising notifications. The 
+.Ar deferred_notifier
+in this example uses the
+.Ar task/defer
+plugin to allow five minutes grace time before raising a notification.
 .Sh SEE ALSO
 .Xr fz 1 ,
 .Xr fzctl 1

--- a/man/man5/flamingzombies.toml.5
+++ b/man/man5/flamingzombies.toml.5
@@ -212,8 +212,15 @@ Send notification using the ntfy web service.
 A phony notifier for testing purposes.
 .It Cm gate/min_priority Ar priority
 Open the gate if it's less than the minimum priority.
-.It Cm gate/state_change
-Open the gate if state has changed from ok to fail or fail to ok.
+.It Cm gate/state_change Ar state
+Open when state has changed, but a notification is yet to be executed.
+.Pp
+Valid options for state are:
+.Bl -tag -width "fail"
+.It Cm ok
+The gate opens after the state flips from fail to ok until a notification is sent.
+.It Cm fail
+The gate opens after the state flips from ok to fail until a notification is sent.
 .El
 .Sh EXAMPLES
 .Pp
@@ -234,20 +241,23 @@ name = "example_notifier"
 command = "notifier/null"
 args = []
 timeout = 5
-gates = [ "state_change" ]
+gates = [
+    ["state_failed"]
+]
 
 [[gate]]
-name = "state_change"
+name = "state_failed"
 command = "gate/state_change"
+args = "fail"
 .Ed
 .Pp
 This will ping 127.0.0.1 every 60 seconds. When the state changes, retries are performed at a rate of once every 5 seconds until 5 consecutive executions agree on the new state.
 .Pp
 At the end of each task execution, the
-.Ar state_change
+.Ar state_failed
 gate of
 .Ar example_notifier
-is executed. The behaviour of this gate is to be open when state either changes from ok to fail, or from fail to ok. When the gate is open, the
+is executed. The behaviour of this gate is to be open when state either changes from ok to fail. When the gate is open, the
 .Ar notifier/null
 notifier is executed.
 .Sh SEE ALSO


### PR DESCRIPTION
Sometimes you want to defer notifications. The `gate/defer` plugin provides that capability.