### PR TITLE
Add the last result's output to the ntfy alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## v0.0.21
 
+- Support emitting output from tasks into notifications.
 - Add `OPEN_GATES` to the environment of notifiers.
-- Add `task/tls_expiration` plugin.
+- Add `task/file_exists` plugin.
 - Add `task/loadavg` plugin.
-- Tag the messages from `ntfy`.
+- Add `task/tls_expiration` plugin.
+- Add tags to messages from `ntfy`.
 
 ## v0.0.20
 

--- a/cmd/fzctl/fzctl.go
+++ b/cmd/fzctl/fzctl.go
@@ -17,15 +17,16 @@ import (
 const VERSION = "v0.0.20"
 
 type taskData struct {
-	Name           string    `json:"name"`
-	State          string    `json:"state"`
-	LastRun        time.Time `json:"last_run"`
-	LastOk         time.Time `json:"last_ok"`
-	Measurements   []bool    `json:"measurements"`
-	ExecutionCount int       `json:"execution_count"`
-	OKCount        int       `json:"ok_count"`
-	FailCount      int       `json:"fail_count"`
-	ErrorCount     int       `json:"error_count"`
+	ErrorCount       int       `json:"error_count"`
+	ExecutionCount   int       `json:"execution_count"`
+	FailCount        int       `json:"fail_count"`
+	LastNotification time.Time `json:"last_notification"`
+	LastOk           time.Time `json:"last_ok"`
+	LastRun          time.Time `json:"last_run"`
+	Measurements     []bool    `json:"measurements"`
+	Name             string    `json:"name"`
+	OKCount          int       `json:"ok_count"`
+	State            string    `json:"state"`
 }
 
 var tasks []taskData
@@ -127,6 +128,7 @@ func show() {
 				fmt.Printf("%-20s%s\n", "name:", t.Name)
 				fmt.Printf("%-20s%s\n", "state:", t.State)
 				fmt.Printf("%-20s%s ago\n", "last execution:", time.Now().Sub(t.LastRun))
+				fmt.Printf("%-20s%s ago\n", "last notification:", time.Now().Sub(t.LastNotification))
 				fmt.Printf("%-20s%s ago\n", "last success:", time.Now().Sub(t.LastOk))
 				fmt.Printf("%-20s%d\n", "executions:", t.ExecutionCount)
 				fmt.Printf("%-20s%d\n", "failures:", t.FailCount)

--- a/lib/daemon/daemon.go
+++ b/lib/daemon/daemon.go
@@ -32,28 +32,30 @@ func processClient(conn net.Conn, c *fz.Config) {
 	defer conn.Close()
 
 	type taskJsonline struct {
-		Name           string    `json:"name"`
-		State          string    `json:"state"`
-		LastRun        time.Time `json:"last_run"`
-		LastOk         time.Time `json:"last_ok"`
-		Measurements   []bool    `json:"measurements"`
-		ExecutionCount int       `json:"execution_count"`
-		OKCount        int       `json:"ok_count"`
-		FailCount      int       `json:"fail_count"`
-		ErrorCount     int       `json:"error_count"`
+		ErrorCount       int       `json:"error_count"`
+		ExecutionCount   int       `json:"execution_count"`
+		FailCount        int       `json:"fail_count"`
+		LastNotification time.Time `json:"last_notification"`
+		LastOk           time.Time `json:"last_ok"`
+		LastRun          time.Time `json:"last_run"`
+		Measurements     []bool    `json:"measurements"`
+		Name             string    `json:"name"`
+		OKCount          int       `json:"ok_count"`
+		State            string    `json:"state"`
 	}
 
 	for _, t := range c.Tasks {
 		d := taskJsonline{
-			Name:           t.Name,
-			State:          fmt.Sprintf("%s", t.State()),
-			LastRun:        t.LastRun,
-			LastOk:         t.LastOk,
-			Measurements:   []bool{},
-			ExecutionCount: t.ExecutionCount,
-			OKCount:        t.OKCount,
-			FailCount:      t.FailCount,
-			ErrorCount:     t.ErrorCount,
+			ErrorCount:       t.ErrorCount,
+			ExecutionCount:   t.ExecutionCount,
+			FailCount:        t.FailCount,
+			LastNotification: t.LastNotification(),
+			LastOk:           t.LastOk,
+			LastRun:          t.LastRun,
+			Measurements:     []bool{},
+			Name:             t.Name,
+			OKCount:          t.OKCount,
+			State:            fmt.Sprintf("%s", t.State()),
 		}
 
 		h := t.History

--- a/lib/fz/notification.go
+++ b/lib/fz/notification.go
@@ -53,7 +53,7 @@ func ProcessNotifications() {
 					fmt.Sprintf("OPEN_GATES=%s", strings.Join(openGatesNames, ",")),
 					fmt.Sprintf("PRIORITY=%d", n.Task.Priority),
 					fmt.Sprintf("STATE=%s", n.Task.State()),
-					fmt.Sprintf("RESULT_OUTPUT=%s", n.Task.LastResultOutput()),
+					fmt.Sprintf("RESULT_OUTPUT=%s", n.Task.LastResultOutput),
 				}
 
 				io.WriteString(stdin, n.body())

--- a/lib/fz/notification.go
+++ b/lib/fz/notification.go
@@ -53,6 +53,7 @@ func ProcessNotifications() {
 					fmt.Sprintf("OPEN_GATES=%s", strings.Join(openGatesNames, ",")),
 					fmt.Sprintf("PRIORITY=%d", n.Task.Priority),
 					fmt.Sprintf("STATE=%s", n.Task.State()),
+					fmt.Sprintf("RESULT_OUTPUT=%s", n.Task.LastResultOutput()),
 				}
 
 				io.WriteString(stdin, n.body())

--- a/lib/fz/task.go
+++ b/lib/fz/task.go
@@ -26,15 +26,16 @@ type Task struct {
 	RecoverBody           string   `toml:"recover_body"`    // the body of the notification when recovering from an error state
 
 	// public, but not configurable
-	LastRun        time.Time
-	LastOk         time.Time
-	LastFail       time.Time
-	History        uint32 // represented in binary. Successes are high
-	HistoryMask    uint32 // the bits in the history with a recorded value. Needed to understand a history of 0
-	ExecutionCount int    // task was executed
-	OKCount        int    // task passed
-	FailCount      int    // task failed
-	ErrorCount     int    // task failed to executed
+	ErrorCount       int       // task failed to executed
+	ExecutionCount   int       // task was executed
+	FailCount        int       // task failed
+	History          uint32    // represented in binary. Successes are high
+	HistoryMask      uint32    // the bits in the history with a recorded value. Needed to understand a history of 0
+	LastFail         time.Time // the time of the last failed execution
+	LastOk           time.Time // the time of the last successfull execution
+	LastResultOutput string    // the result output of the last execution
+	LastRun          time.Time // the time of the last execution
+	OKCount          int       // task passed
 
 	mutex             sync.Mutex  // lock to ensure one task runs at a time
 	lastNotifications []time.Time // times that each notifier was last executed

--- a/lib/fz/task.go
+++ b/lib/fz/task.go
@@ -106,7 +106,7 @@ func (t *Task) Run() bool {
 
 	errorMessage, _ := io.ReadAll(stderr)
 	stdoutBytes, _ := io.ReadAll(stdout)
-	t.LastResultOutput = string(stdoutBytes)
+	t.LastResultOutput = strings.TrimSuffix(string(stdoutBytes), "\n")
 
 	err = cmd.Wait()
 

--- a/lib/fz/task.go
+++ b/lib/fz/task.go
@@ -292,6 +292,23 @@ func (t Task) NotifierIndex(name string) (int, error) {
 	return -1, fmt.Errorf("unknown notifier name")
 }
 
+// get the last notification of all notifiers.
+func (t Task) LastNotification() time.Time {
+	var ts time.Time
+
+	for i, n := range t.lastNotifications {
+		if i == 0 {
+			ts = n
+		} else {
+			if n.Unix() > ts.Unix() {
+				ts = n
+			}
+		}
+	}
+
+	return ts
+}
+
 func (t Task) GetLastNotification(name string) time.Time {
 	i, err := t.NotifierIndex(name)
 	if err != nil {

--- a/lib/fz/task.go
+++ b/lib/fz/task.go
@@ -94,6 +94,7 @@ func (t *Task) Run() bool {
 	}
 
 	stderr, _ := cmd.StderrPipe()
+	stdout, _ := cmd.StdoutPipe()
 
 	err := cmd.Start()
 	if err != nil {
@@ -104,6 +105,8 @@ func (t *Task) Run() bool {
 	t.ExecutionCount++
 
 	errorMessage, _ := io.ReadAll(stderr)
+	stdoutBytes, _ := io.ReadAll(stdout)
+	t.LastResultOutput = string(stdoutBytes)
 
 	err = cmd.Wait()
 

--- a/libexec/gate/renotify
+++ b/libexec/gate/renotify
@@ -5,8 +5,12 @@ DELAY_SECONDS=${1:-0}
 
 # exit 1 until the regular notification has been made
 case "${LAST_STATE}" in
-  "fail") [ "${LAST_OK}" -lt "${LAST_NOTIFICATION}" ]   && exit 1 ;;
-  "ok")   [ "${LAST_FAIL}" -lt "${LAST_NOTIFICATION}" ] && exit 1 ;;
+  "fail") [ "${LAST_NOTIFICATION}" -lt "${LAST_OK}" ] && exit 1 ;;
+  "ok")   [ "${LAST_NOTIFICATION}" -lt "${LAST_FAIL}" ] && exit 1 ;;
 esac
 
-[ $((LAST_NOTIFICATION+DELAY_SECONDS)) -gt "${NOW}" ]
+if [ "${LAST_NOTIFICATION}" -lt "$((NOW-DELAY_SECONDS))" ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/libexec/gate/to_state
+++ b/libexec/gate/to_state
@@ -2,12 +2,12 @@
 
 case $1 in
   "ok")
-    [ "${STATE}" = "ok" ]                           \
+    [ "${STATE}" = "ok" ]                              \
       && [ "${LAST_NOTIFICATION}" -le "${LAST_FAIL}" ] \
       && exit 0
     ;;
   "fail")
-    [ "${STATE}" = "fail" ]                           \
+    [ "${STATE}" = "fail" ]                          \
       && [ "${LAST_NOTIFICATION}" -le "${LAST_OK}" ] \
       && exit 0
     ;;

--- a/libexec/notifier/ntfy
+++ b/libexec/notifier/ntfy
@@ -24,7 +24,6 @@ _send() {
     -H "Title: ${subject}"                                       \
     -H "Priority: ${ntfy_priority}"                              \
     -H "X-Tags: ${status_tag},host:$(hostname -s),${OPEN_GATES}" \
-    -H "Markdown: yes"                                           \
     "ntfy.sh/${NTFY_TOPIC}"
 }
 
@@ -37,7 +36,7 @@ NTFY_TOPIC="$1"
 DATAFILE=$(mktemp)
 
 cat <<EOF > "${DATAFILE}"
-> ${RESULT_OUTPUT}
+${RESULT_OUTPUT}
 ---
 $(timeout 0.2 cat)
 EOF

--- a/libexec/notifier/ntfy
+++ b/libexec/notifier/ntfy
@@ -23,7 +23,7 @@ _send() {
   curl -v -f --data-binary @"${DATAFILE}"                        \
     -H "Title: ${subject}"                                       \
     -H "Priority: ${ntfy_priority}"                              \
-    -H "X-Tags: ${status_tag},host:$(hostname -s),${OPEN_GATES}" \
+    -H "X-Tags: ${status_tag},host:$(hostname -s),last_state:${LAST_STATE},${OPEN_GATES}" \
     "ntfy.sh/${NTFY_TOPIC}"
 }
 

--- a/libexec/notifier/ntfy
+++ b/libexec/notifier/ntfy
@@ -4,29 +4,44 @@
 # https://github.com/binwiederhier/ntfy
 #
 
+_send() {
+  subject="${NAME}: state ${STATE}"
+
+  case "${PRIORITY}" in
+    1) ntfy_priority="max"     ;;
+    2) ntfy_priority="high"    ;;
+    3) ntfy_priority="default" ;;
+    4) ntfy_priority="low"     ;;
+    5) ntfy_priority="min"     ;;
+    *) ntfy_priority="default" ;;
+  esac
+
+  status_tag="gray_question"
+  [ "${STATE}" = "ok" ] && status_tag="green_circle"
+  [ "${STATE}" = "fail" ] && status_tag="red_circle"
+
+  curl -v -f --data-binary @"${DATAFILE}"                        \
+    -H "Title: ${subject}"                                       \
+    -H "Priority: ${ntfy_priority}"                              \
+    -H "X-Tags: ${status_tag},host:$(hostname -s),${OPEN_GATES}" \
+    -H "Markdown: yes"                                           \
+    "ntfy.sh/${NTFY_TOPIC}"
+}
+
 if [ $# -eq 0 ]; then
   echo "you must supply the topic as first argument" >&2
   exit 1
 fi
 
-TOPIC="$1"
-SUBJECT="${NAME}: state ${STATE}"
+NTFY_TOPIC="$1"
+DATAFILE=$(mktemp)
 
-case "${PRIORITY}" in
-  1) NTFY_PRIORITY="max"     ;;
-  2) NTFY_PRIORITY="high"    ;;
-  3) NTFY_PRIORITY="default" ;;
-  4) NTFY_PRIORITY="low"     ;;
-  5) NTFY_PRIORITY="min"     ;;
-  *) NTFY_PRIORITY="default" ;;
-esac
+cat <<EOF > "${DATAFILE}"
+> ${RESULT_OUTPUT}
+---
+$(timeout 0.2 cat)
+EOF
 
-status_tag="gray_question"
-[ "${STATE}" = "ok" ] && status_tag="green_circle"
-[ "${STATE}" = "fail" ] && status_tag="red_circle"
+_send
 
-timeout 0.2 cat | curl -v -f -d @-                             \
-  -H "Title: ${SUBJECT}"                                       \
-  -H "Priority: ${NTFY_PRIORITY}"                              \
-  -H "X-Tags: ${status_tag},host:$(hostname -s),${OPEN_GATES}" \
-  "ntfy.sh/${TOPIC}"
+rm -f "${DATAFILE}"

--- a/libexec/task/file_exists
+++ b/libexec/task/file_exists
@@ -1,0 +1,5 @@
+#!/bin/sh
+if ! [ -f "$1" ]; then
+    echo "file '$1' does not exist"
+    exit 1
+fi

--- a/libexec/task/loadavg
+++ b/libexec/task/loadavg
@@ -10,9 +10,13 @@ uptime \
       {
         sub(",","",$(NF-1))
         v=$(NF-1)
+      }
+      END {
         if (v>threshold) {
           print "loadavg (" v ") exceeded threshold (" threshold ")"
           exit 1
+        } else {
+          print "loadavg (" v ") is ok"
         }
       }
     '

--- a/libexec/task/loadavg
+++ b/libexec/task/loadavg
@@ -11,7 +11,7 @@ uptime \
         sub(",","",$(NF-1))
         v=$(NF-1)
         if (v>threshold) {
-          print "threshold exceeded" > "/dev/stderr"
+          print "loadavg (" v ") exceeded threshold (" threshold ")"
           exit 1
         }
       }

--- a/libexec/task/port_open
+++ b/libexec/task/port_open
@@ -4,4 +4,4 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
-/usr/bin/nc -zv "$1" "$2"
+/usr/bin/nc -zv "$1" "$2" 2>&1

--- a/man/man5/flamingzombies.toml.5
+++ b/man/man5/flamingzombies.toml.5
@@ -222,6 +222,10 @@ Number of seconds before the certificate expires that the task fails.
 .El
 .It Cm task/loadavg Op threshold
 Check that the 1m load average is below the threshold. The default threshold value is 1.0.
+.It Cm task/file_exists Ar file
+Check that
+.Ar file
+exists and is a file.
 .It Cm notifier/email
 Send notification using the local MTA.
 .It Cm notifier/ntfy Ar topic

--- a/man/man7/fz-tasks.7
+++ b/man/man7/fz-tasks.7
@@ -13,10 +13,25 @@ Tasks are executed with metadata inserted into the environment. These values are
 The number of seconds the task may run before
 .Xr fz
 times out the script.
+.Sh OUTPUT
+Tasks use both stdout and stderr output streams.
+.Bl -tag -width Ds
+.It Cm stdout
+Everything sent to stdout is provided to the notifier in the
+.Cm RESULT_OUTPUT
+environment variable.
+One line should be sufficient. If you need more detail than this, it's usually better to configure an
+.Ar error_body
+or
+.Ar recover_body
+on the task's definition.
+.It Cm stderr
+All data sent to stderr is written to DEBUG logs.
+.El
 .Sh EXIT CODES
 The following exit codes are supported:
 .Pp
-.Bl -tag -width XX
+.Bl -tag -width XXX
 .It Cm 0
 The task measured ok
 .It Cm 3


### PR DESCRIPTION
It's helpful to know which condition caused a task to fail, or by how far the threshold was exceeded. A tasks stdout is now collected and made available to notifiers.

This PR also added some bits to make testing it easier.