### PR TITLE
Better timeout handling in fz_errors plugin

### DIFF
--- a/libexec/gate/renotify
+++ b/libexec/gate/renotify
@@ -9,7 +9,7 @@ case "${LAST_STATE}" in
   "ok")   [ "${LAST_NOTIFICATION}" -lt "${LAST_FAIL}" ] && exit 1 ;;
 esac
 
-if [ "${LAST_NOTIFICATION}" -lt "$((NOW-DELAY_SECONDS))" ]; then
+if [ "${LAST_NOTIFICATION}" -le "$((NOW-DELAY_SECONDS))" ]; then
   exit 0
 else
   exit 1

--- a/libexec/task/fz_errors
+++ b/libexec/task/fz_errors
@@ -3,7 +3,7 @@ if [ $# -eq 2 ]; then
   export FZ_LISTEN="$1:$2"
 fi
 
-_fz_online() { fzctl &>/dev/null || exit 3; }
+_fz_online() { fzctl >/dev/null 2>&1 || exit 3; }
 _fz_tasks() { fzctl list | awk '{ print $1 }'; }
 
 # the state is unknown if fzctl cannot be called.

--- a/libexec/task/fz_errors
+++ b/libexec/task/fz_errors
@@ -3,7 +3,7 @@ if [ $# -eq 2 ]; then
   export FZ_LISTEN="$1:$2"
 fi
 
-_fz_online() { fzctl || exit 3; }
+_fz_online() { fzctl &>/dev/null || exit 3; }
 _fz_tasks() { fzctl list | awk '{ print $1 }'; }
 
 # the state is unknown if fzctl cannot be called.
@@ -23,4 +23,4 @@ fzctl show $(_fz_tasks) | awk '
       if (errors>0)
         exit 1
     }
-  ' >&2
+  '

--- a/libexec/task/fz_errors
+++ b/libexec/task/fz_errors
@@ -1,16 +1,23 @@
 #!/bin/sh
+set -e
+
 if [ $# -eq 2 ]; then
   export FZ_LISTEN="$1:$2"
 fi
 
-_fz_online() { fzctl >/dev/null 2>&1 || exit 3; }
-_fz_tasks() { fzctl list | awk '{ print $1 }'; }
+if [ "${TIMEOUT}" -le 2 ]; then
+  echo "the timeout must be greater than 2 seconds." >&2
+  exit 3
+fi
 
-# the state is unknown if fzctl cannot be called.
-_fz_online
+tasks="$(timeout 1 fzctl list | awk '{ print $1 }')"
+if [ "$(echo "${tasks}" | wc -w)" -eq 0 ]; then
+  echo "no tasks were found"
+  exit 3
+fi
 
-# shellcheck disable=SC2046
-fzctl show $(_fz_tasks) | awk '
+# shellcheck disable=SC2086
+timeout 1 fzctl show ${tasks} | awk '
     BEGIN { errors=0 }
     /^name:/ { name=$2 }
     /^errors:/ {


### PR DESCRIPTION
The task is timing out, causing an error that cannot be recovered from. This doesn't prevent the inescapble error condition, but it does reduce the chance of a timeout.